### PR TITLE
The language node seems to be incorrect

### DIFF
--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,4 +1,4 @@
-de:
+tr:
   formtastic:
     :yes: "Evet"
     :no: "Hayır"


### PR DESCRIPTION
I think the translation language node in the YAML file should be "tr" as in Turkish, not "de" as in German.
