### PR TITLE
Add en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,10 @@
+en:
+  formtastic:
+    :yes: 'Yes'
+    :no: 'No'
+    :create: 'Create %{model}'
+    :update: 'Update %{model}'
+    :submit: 'Submit %{model}'
+    :cancel: 'Cancel %{model}'
+    :reset: 'Reset %{model}'
+    :required: 'required'


### PR DESCRIPTION
Formtastic does not distribute this file in `config`, so `en` it is not managed as a common locale

https://github.com/justinfrench/formtastic/blob/master/lib/locale/en.yml

Related to #8 